### PR TITLE
Fix alias bug

### DIFF
--- a/src/main/java/seedu/address/logic/commands/Command.java
+++ b/src/main/java/seedu/address/logic/commands/Command.java
@@ -42,7 +42,17 @@ public abstract class Command {
         return List.copyOf(COMMAND_WORDS);
     }
 
-    public static boolean isExistingCommand(String commandWord) {
-        return COMMAND_WORDS.stream().anyMatch(existingCommandWord -> existingCommandWord.equals(commandWord));
+    /**
+     * Checks whether the given string is an existing command word.
+     */
+    public static boolean isExistingCommand(String s) {
+        return COMMAND_WORDS.stream().anyMatch(existingCommandWord -> s.equals(existingCommandWord));
+    }
+
+    /**
+     * Checks whether the the given string contains an existing command word.
+     */
+    public static boolean isContainingExistingCommand(String s) {
+        return COMMAND_WORDS.stream().anyMatch(existingCommandWord -> s.contains(existingCommandWord));
     }
 }

--- a/src/main/java/seedu/address/logic/commands/Command.java
+++ b/src/main/java/seedu/address/logic/commands/Command.java
@@ -48,11 +48,4 @@ public abstract class Command {
     public static boolean isExistingCommand(String s) {
         return COMMAND_WORDS.stream().anyMatch(existingCommandWord -> s.equals(existingCommandWord));
     }
-
-    /**
-     * Checks whether the the given string contains an existing command word.
-     */
-    public static boolean isContainingExistingCommand(String s) {
-        return COMMAND_WORDS.stream().anyMatch(existingCommandWord -> s.contains(existingCommandWord));
-    }
 }

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -126,13 +126,20 @@ public class AddressBookParser {
         }
     }
 
-    private String replaceAlias(String userInput) {
+    /**
+     * Replaces alias with the aliased command.
+     */
+    public String replaceAlias(String userInput) {
         Set<String> aliases = model.getExistingAlias();
 
         String longestMatchingAlias = null;
 
+        // userInput with trailing space, as we want to replace the word, not a substring of a word
+        // This quick fix works for one word input as well
+        String userInputTrailingSpace = userInput + " ";
+
         for (String alias: aliases) {
-            if (userInput.indexOf(alias) != 0) {
+            if (userInputTrailingSpace.indexOf(alias + " ") != 0) {
                 continue;
             }
 

--- a/src/main/java/seedu/address/logic/parser/AliasCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AliasCommandParser.java
@@ -10,7 +10,7 @@ public class AliasCommandParser implements Parser<AliasCommand> {
 
     public static final String MESSAGE_INVALID_COMMAND_ALIAS = "%1$s is not an existing command word";
 
-    public static final String MESSAGE_INVALID_ALIAS = "%1$s contains an existing command word. "
+    public static final String MESSAGE_INVALID_ALIAS = "%1$s is an existing command word. "
             + "It cannot be used as an alias";
 
     @Override
@@ -28,7 +28,7 @@ public class AliasCommandParser implements Parser<AliasCommand> {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_ALIAS, command));
         }
 
-        if (Command.isContainingExistingCommand(alias)) {
+        if (Command.isExistingCommand(alias)) {
             throw new ParseException(String.format(MESSAGE_INVALID_ALIAS, alias));
         }
 

--- a/src/main/java/seedu/address/logic/parser/AliasCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AliasCommandParser.java
@@ -10,7 +10,7 @@ public class AliasCommandParser implements Parser<AliasCommand> {
 
     public static final String MESSAGE_INVALID_COMMAND_ALIAS = "%1$s is not an existing command word";
 
-    public static final String MESSAGE_INVALID_ALIAS = "%1$s is an existing command word. "
+    public static final String MESSAGE_INVALID_ALIAS = "%1$s contains an existing command word. "
             + "It cannot be used as an alias";
 
     @Override
@@ -28,7 +28,7 @@ public class AliasCommandParser implements Parser<AliasCommand> {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_ALIAS, command));
         }
 
-        if (Command.isExistingCommand(alias)) {
+        if (Command.isContainingExistingCommand(alias)) {
             throw new ParseException(String.format(MESSAGE_INVALID_ALIAS, alias));
         }
 

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -35,6 +35,7 @@ import seedu.address.logic.commands.TagCommand;
 import seedu.address.logic.commands.UntagAllCommand;
 import seedu.address.logic.commands.UntagCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.person.NameAndTagsContainKeywordsPredicate;
 import seedu.address.model.person.Person;
@@ -184,5 +185,26 @@ public class AddressBookParserTest {
     @Test
     public void parseCommand_unknownCommand_throwsParseException() {
         assertThrows(ParseException.class, MESSAGE_UNKNOWN_COMMAND, () -> parser.parseCommand("unknownCommand"));
+    }
+
+    @Test
+    public void replaceAlias() {
+        Model model = new ModelManager();
+        model.addAlias("h", "help");
+        model.addAlias("ta", "tagall");
+
+        AddressBookParser parser = new AddressBookParser(model);
+
+        // EP: no-param commands
+        assertEquals("help", parser.replaceAlias("h"));
+
+        // EP: param commands
+        assertEquals("tagall os", parser.replaceAlias("ta os"));
+
+        // EP: matching substring (not whole string) that matches at index 0
+        assertEquals("taga", parser.replaceAlias("taga"));
+
+        // EP: matching word whose matching index != 0
+        assertEquals("tagall ta", parser.replaceAlias("tagall ta"));
     }
 }


### PR DESCRIPTION
A bug was reported that prefix of existing command should show error
message, despite of the warning given in the user guide. Another bug
reported is that alias can contain existing command word.

Alias replacement is done if it matches a word instead of substring.

It helps to create a more robust system.

Resolves: #151, #142