### PR TITLE
Fix bug for Untag Command

### DIFF
--- a/src/main/java/seedu/address/logic/commands/UntagCommand.java
+++ b/src/main/java/seedu/address/logic/commands/UntagCommand.java
@@ -37,7 +37,7 @@ public class UntagCommand extends Command {
     public static final String MESSAGE_NO_DISPLAYED_PERSONS = "No persons displayed to untag.";
     public static final String MESSAGE_OUT_OF_BOUNDS_INDEX_DISPLAYED = "%1$d is an out-of-bounds index.\n"
             + "Indexes up to %2$d are valid.";
-    public static final String MESSAGE_TAG_NOT_EXIST = "This tag does not exist among the selected persons: %s";
+    public static final String MESSAGE_TAG_NOT_EXIST = "None of the selected persons contain the tag: %s";
 
     private final List<Index> targetIndexes;
     private final Tag tagToDelete;

--- a/src/main/java/seedu/address/logic/commands/UntagCommand.java
+++ b/src/main/java/seedu/address/logic/commands/UntagCommand.java
@@ -34,12 +34,14 @@ public class UntagCommand extends Command {
             + "Example: " + COMMAND_WORD + " 1 " + "friend";
 
     public static final String MESSAGE_UNTAG_PERSON_SUCCESS = "Deleted %s Tag";
-    public static final String MESSAGE_NO_DISPLAYED_PERSONS = "No persons displayed to tag.";
+    public static final String MESSAGE_NO_DISPLAYED_PERSONS = "No persons displayed to untag.";
     public static final String MESSAGE_OUT_OF_BOUNDS_INDEX_DISPLAYED = "%1$d is an out-of-bounds index.\n"
             + "Indexes up to %2$d are valid.";
+    public static final String MESSAGE_TAG_NOT_EXIST = "This tag does not exist among the selected persons: %s";
 
     private final List<Index> targetIndexes;
     private final Tag tagToDelete;
+    private boolean isTagPresent;
 
     /**
      * Creates an UntagCommand to delete the specified {@code Tag} from the person
@@ -51,6 +53,7 @@ public class UntagCommand extends Command {
 
         this.targetIndexes = targetIndexes;
         this.tagToDelete = tagToDelete;
+        this.isTagPresent = false;
     }
 
     @Override
@@ -73,7 +76,10 @@ public class UntagCommand extends Command {
         Set<Tag> existingTags = personToDeleteTag.getTags();
         Set<Tag> updatedTags = new HashSet<>();
         updatedTags.addAll(existingTags);
-        updatedTags.remove(tagToDelete);
+        if (updatedTags.remove(tagToDelete)) {
+            isTagPresent = true;
+        }
+
         return new Person(name, phone, email, github, linkedIn, detail, updatedTags);
 
     }
@@ -98,10 +104,13 @@ public class UntagCommand extends Command {
 
         }
 
-
         for (Person personToUntag: personsToUntag) {
             Person untaggedPerson = untag(personToUntag);
             model.setPerson(personToUntag, untaggedPerson);
+        }
+
+        if (!isTagPresent) {
+            throw new CommandException(String.format(MESSAGE_TAG_NOT_EXIST, tagToDelete));
         }
 
     }

--- a/src/test/java/seedu/address/logic/commands/UntagCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/UntagCommandTest.java
@@ -129,6 +129,19 @@ class UntagCommandTest {
     }
 
     @Test
+    public void execute_tagNotFound_failure() {
+        Index indexSecondPerson = Index.fromOneBased(2);
+        List<Index> secondIndex = new ArrayList<>();
+        secondIndex.add(INDEX_SECOND_PERSON);
+
+        UntagCommand untagCommand = new UntagCommand(secondIndex, tag);
+        assertCommandFailure(untagCommand, model,
+                String.format(UntagCommand.MESSAGE_TAG_NOT_EXIST, tag));
+
+
+    }
+
+    @Test
     void testEquals() {
         List<Index> firstIndex = new ArrayList<>();
         List<Index> secondIndex = new ArrayList<>();


### PR DESCRIPTION
Untag Command does not return error message when all selected persons do not have the specific tag

Add check to ensure tag is present, else return error message that tag not present